### PR TITLE
Link to correct flumeViewQuery file and call the imported function right.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var pull = require('pull-stream')
-var FlumeQueryLinks = require('flumeview-query/links')
+var FlumeViewQuery = require('flumeview-query')
 var path = require('path')
 
 var extractLinks = require('./links')
@@ -26,7 +26,7 @@ exports.manifest = {
 }
 
 exports.init = function (ssb, config) {
-  var s = ssb._flumeUse('links2', FlumeQueryLinks(indexes, extractLinks, 3))
+  var s = ssb._flumeUse('links2', FlumeViewQuery(3, {indexes, extractLinks}))
   var read = s.read
   s.read = function (opts) {
     if(!opts) opts = {}


### PR DESCRIPTION
There seems to be a small issue when calling flumeview-query.
When executing this plugin (from a fresh install) the following error is
raised:

```
ssb-server 14.1.12 /Users/user/.ssb logging.level:notice
my key ID: ************************
internal/modules/cjs/loader.js:670
    throw err;
    ^

Error: Cannot find module 'flumeview-query/links'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:668:15)
    at Function.Module._load (internal/modules/cjs/loader.js:591:27)
    at Module.require (internal/modules/cjs/loader.js:723:19)
    at require (internal/modules/cjs/helpers.js:14:16)
    at Object.<anonymous> (/Users/user/ssb/node_modules/ssb-links/index.js:2:23)
    at Module._compile (internal/modules/cjs/loader.js:816:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:827:10)
    at Module.load (internal/modules/cjs/loader.js:685:32)
    at Function.Module._load (internal/modules/cjs/loader.js:620:12)
    at Module.require (internal/modules/cjs/loader.js:723:19)
```

Checking in with the flumeView-query code it quickly turns out:
- The wrong file is being called, there is no query ./links file in the FlumeView repo.
- The right function is being called in the wrong order. This could be due to some kind of update

I've fixed the file and am now calling the functions according to:
https://github.com/flumedb/flumeview-query#api--flumeviewqueryversion-indexes-filter-map--flumeview-query

It's up to the maintainer to decide if the index should be raised from 3 to 4.

Edit: indexes in the line above should be "versions" as per:

> version must be an number. When you update any options, change the version and the index will rebuild. opts is the options. in particular {indexes: [...]} is mandatory.
https://github.com/flumedb/flumeview-query#api--flumeviewqueryversion-indexes-filter-map--flumeview-query