### PR TITLE
Prevent objects from getting into rel

### DIFF
--- a/links.js
+++ b/links.js
@@ -1,5 +1,11 @@
 var msgs = require('ssb-msgs')
 
+function noObjects(value) {
+  if (Array.isArray(value)) return value.map(noObjects)
+  if (typeof value === 'object' && value !== null) return JSON.stringify(value)
+  return value
+}
+
 module.exports = function (data, iter) {
   if(data.sync) return
   var content = data.value.content
@@ -53,7 +59,7 @@ module.exports = function (data, iter) {
 
     iter({
       source: source, dest: dest,
-      rel: rel,
+      rel: rel.map(noObjects),
       ts: data.timestamp
     })
   })


### PR DESCRIPTION
This prevents a crash which occurs when replicating certain messages.

<details>
<summary>Crash</summary>

```
/home/cel/.local/lib/node_modules/ssb-server/node_modules/charwise/codec/object.js:27
        if (!Array.isArray(array)) { throw new Error('can only encode arrays'); }
                                           ^

Error: can only encode arrays
    at encode (/home/cel/.local/lib/node_modules/ssb-server/node_modules/charwise/codec/object.js:27:44)
    at encodeItem (/home/cel/.local/lib/node_modules/ssb-server/node_modules/charwise/codec/object.js:41:20)
    at encode (/home/cel/.local/lib/node_modules/ssb-server/node_modules/charwise/codec/object.js:33:24)
    at encodeItem (/home/cel/.local/lib/node_modules/ssb-server/node_modules/charwise/codec/object.js:41:20)
    at Object.encode (/home/cel/.local/lib/node_modules/ssb-server/node_modules/charwise/codec/object.js:33:24)
    at Object.exports.encode (/home/cel/.local/lib/node_modules/ssb-server/node_modules/charwise/index.js:39:28)
    at Codec.encodeKey (/home/cel/.local/lib/node_modules/ssb-server/node_modules/level-codec/index.js:32:45)
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/level-codec/index.js:53:17
    at Array.map (<anonymous>)
    at Codec.encodeBatch (/home/cel/.local/lib/node_modules/ssb-server/node_modules/level-codec/index.js:50:14)
    at DB._batch (/home/cel/.local/lib/node_modules/ssb-server/node_modules/encoding-down/index.js:70:20)
    at DB.AbstractLevelDOWN.batch (/home/cel/.local/lib/node_modules/ssb-server/node_modules/abstract-leveldown/abstract-leveldown.js:179:8)
    at LevelUP.batch (/home/cel/.local/lib/node_modules/ssb-server/node_modules/levelup/lib/levelup.js:255:11)
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/flumeview-level/index.js:73:14
    at flush (/home/cel/.local/lib/node_modules/ssb-server/node_modules/pull-write/index.js:49:7)
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/pull-write/index.js:37:33
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/pull-write/index.js:41:13
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/pull-stream/throughs/async-map.js:39:20
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/flumedb/index.js:60:13
    at Array.unboxerMap (/home/cel/.local/lib/node_modules/ssb-server/node_modules/ssb-db/minimal.js:85:35)
    at chainMaps (/home/cel/.local/lib/node_modules/ssb-server/node_modules/ssb-db/minimal.js:90:14)
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/flumedb/index.js:56:9
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/pull-stream/throughs/async-map.js:32:13
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/pull-stream/throughs/filter.js:17:11
    at /home/cel/.local/lib/node_modules/ssb-server/node_modules/pull-cursor/skip.js:14:16
```
</details>

<details>
<summary>Message</summary>

```json
{
  "key": "%lBk9QeX1S/iYeC6Y2cFhh7qiZGqswg2TnDzclWsfsQE=.sha256",
  "value": {
    "previous": "%xrBvJpomKI/GhXjS/ZbVX2KpN2CaR/I/0JaqQLBCXkY=.sha256",
    "sequence": 52,
    "author": "@SVMnpeuQ7zRVIkdayCktshahIw6oovJgKiiNoeM5nF8=.ed25519",
    "timestamp": 1602014905406,
    "hash": "sha256",
    "content": {
      "type": "post",
      "text": "hopefully there is a picture",
      "mentions": [
        {
          "name": "trio.jpeg",
          "link": "&Fj5JVn7vDAXhVNsgdDg9Dc/44Ezv37MRTfmkF2J3g+U=.sha256",
          "size": {
            "dev": 1991025716,
            "mode": 33206,
            "nlink": 1,
            "uid": 0,
            "gid": 0,
            "rdev": 0,
            "blksize": 4096,
            "ino": 5066549581027855,
            "size": 14118,
            "blocks": 32,
            "atimeMs": 1602014905341.5027,
            "mtimeMs": 1599578648743.5425,
            "ctimeMs": 1599584494100.568,
            "birthtimeMs": 1599579927920.083,
            "atime": "2020-10-06T20:08:25.342Z",
            "mtime": "2020-09-08T15:24:08.744Z",
            "ctime": "2020-09-08T17:01:34.101Z",
            "birthtime": "2020-09-08T15:45:27.920Z"
          },
          "type": "jpeg"
        }
      ]
    },
    "signature": "MjvZ4OEnaRH5AJ1Wnk6Hgh7XV9arSeYOhJhuFKmk+6Tlv+dY5j2V/EMwmMQRP83esJf0P1kgZW1tFe5J/hu5CA==.sig.ed25519"
  },
  "timestamp": 1602025362258
}
```
</details>